### PR TITLE
Ported from carton PR #191: When executing carmel exec COMMAND on Win

### DIFF
--- a/lib/Carmel/Runner.pm
+++ b/lib/Carmel/Runner.pm
@@ -2,7 +2,7 @@ package Carmel::Runner;
 use strict;
 use warnings;
 
-our $UseSystem = 0;
+our $UseSystem = ($^O eq 'MSWin32');
 
 sub new {
     my $class = shift;


### PR DESCRIPTION
Ported from carton PR #191: When executing carmel exec COMMAND on Windows,

the command returns from the command prompt while it's running.

Using system instead of exec on Windows makes carmel behave correctly
