### PR TITLE
use PERL_FILE_TEMP_CLEANUP=0 to keep build directories

### DIFF
--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -155,7 +155,11 @@ sub install_with_cpanfile {
 sub install {
     my($self, @args) = @_;
 
-    my $dir = Path::Tiny->tempdir;
+    my %file_temp = ();
+    $file_temp{CLEANUP} = $ENV{PERL_FILE_TEMP_CLEANUP}
+      if exists $ENV{PERL_FILE_TEMP_CLEANUP};
+
+    my $dir = Path::Tiny->tempdir(%file_temp);
     local $ENV{PERL_CPANM_HOME} = $dir;
     local $ENV{PERL_CPANM_OPT};
 


### PR DESCRIPTION
This patch keeps the build directories during `carmel install` so you can read `build.log` when something fails.