### PR TITLE
windows home uninitialized problem

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -21,6 +21,7 @@ requires 'Carton', 'v1.0.13';
 # vendor
 requires 'Menlo', '1.9000';
 requires 'CPAN::Common::Index', '0.006';
+requires 'File::HomeDir', '1.00';
 
 on test => sub {
     requires 'Test::More', '0.96';

--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -16,6 +16,7 @@ use Path::Tiny ();
 use Pod::Usage ();
 use File::pushd;
 use Try::Tiny;
+use File::HomeDir;
 
 use Class::Tiny {
     verbose => sub { 0 },
@@ -63,7 +64,9 @@ sub run {
 
 sub repository_base {
     my $self = shift;
-    Path::Tiny->new($ENV{PERL_CARMEL_REPO} || "$ENV{HOME}/.carmel/" . $self->perl_arch);
+
+    my $home = File::HomeDir->my_home;
+    Path::Tiny->new($ENV{PERL_CARMEL_REPO} || "$home/.carmel/" . $self->perl_arch);
 }
 
 sub repo {


### PR DESCRIPTION
windows don't have set HOME environment variable (have HOMEPATH)
for multiplatform compatibilty I use File::HomeDir module
this fix: 
```
Use of uninitialized value $ENV{"HOME"} in concatenation (.) or string at C:/Perl64/site/lib/Carmel/App.pm line 66.
```