### PR TITLE
Windows home

### DIFF
--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -63,7 +63,9 @@ sub run {
 
 sub repository_base {
     my $self = shift;
-    Path::Tiny->new($ENV{PERL_CARMEL_REPO} || "$ENV{HOME}/.carmel/" . $self->perl_arch);
+
+    my $home = $ENV{HOME} || $ENV{HOMEPATH};
+    Path::Tiny->new($ENV{PERL_CARMEL_REPO} || "$home/.carmel/" . $self->perl_arch);
 }
 
 sub repo {


### PR DESCRIPTION
windows don't have set HOME environment variable (have HOMEPATH)
for multiplatform compatibilty I use HOME or HOMEPATH variable
this fix: "Use of uninitialized value $ENV{"HOME"} in concatenation (.) or string at C:/Perl64/site/lib/Carmel/App.pm line 66."