### PR TITLE
Fix #41 Implement locking with flock to avoid multiple carmel commands run

### DIFF
--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 
 use Carmel;
+use Carmel::Lock;
 use Carmel::Runner;
 use Carp ();
 use Carmel::Repository;
@@ -235,6 +236,8 @@ sub install {
     # one mirror for now
     my $mirror = Module::CPANfile->load($cpanfile)->mirrors->[0];
 
+    my $lock = $self->acquire_lock;
+
     # cleanup perl5 in case it was left from previous runs
     my $lib = $self->repository_base->child('perl5');
     $lib->remove_tree({ safe => 0 });
@@ -259,6 +262,16 @@ sub install {
     }
 
     $lib->remove_tree({ safe => 0 });
+}
+
+sub acquire_lock {
+    my $self = shift;
+
+    my $path = $self->repository_base->child("lock");
+    my $lock = Carmel::Lock->new( path => $path );
+    $lock->acquire;
+
+    return $lock;
 }
 
 sub quote {

--- a/lib/Carmel/Lock.pm
+++ b/lib/Carmel/Lock.pm
@@ -9,6 +9,7 @@ sub acquire {
     my $self = shift;
 
     my $path = $self->path;
+    $path->parent->mkpath;
 
     my $fh = $path->opena or die "$path: $!";
     $self->_handle($fh);

--- a/lib/Carmel/Lock.pm
+++ b/lib/Carmel/Lock.pm
@@ -1,0 +1,47 @@
+package Carmel::Lock;
+use strict;
+use warnings;
+
+use Fcntl qw(:flock);
+use Class::Tiny qw( path _handle );
+
+sub acquire {
+    my $self = shift;
+
+    my $path = $self->path;
+
+    my $fh = $path->opena or die "$path: $!";
+    $self->_handle($fh);
+    
+    while (1) {
+        # try non-blocking first to show warning
+        flock $fh, LOCK_EX|LOCK_NB and last;
+
+        # don't use slurp since it opens with LOCK_SH
+        chomp( my $pid = $path->openr->getline );
+        warn "Waiting for another carmel command (pid:$pid) to finish.\n";
+
+        local $SIG{ALRM} = sub { die "Timing out. Remove the file $path if this is a stale lock.\n" };
+        alarm 3600; # make this an environment var?
+
+        flock $fh, LOCK_EX or die "lock failed: $!";
+
+        last;
+    }
+
+    truncate $fh, 0;
+    print $fh "$$\n";
+    $fh->flush;
+}
+
+sub DESTROY {
+    my $self = shift;
+    $self->release;
+}
+
+sub release {
+    my $self = shift;
+    $self->_handle->close if $self->_handle;
+}
+
+1;


### PR DESCRIPTION
When you run multiple instances of `carmel install` on the same host, the commands will try to install the modules to the temporary directory C<$HOME/.carmel/{version}-{arch}/perl5> to determine what needs to be installed.

To avoid that we either have to:

- prevent from multiple instances of carmel running at the same time (This PR), or
- make the perl5 directory unique to each process

The latter would be actually more appealing but leaves us some cleanup problem when SIGINT is sent with C-c. This PR adds a flock-based exclusive locking so that while another instance is running, carmel will wait until the ex-lock becomes available.