### PR TITLE
Implement carmel pin Module@version

### DIFF
--- a/lib/Carmel.pm
+++ b/lib/Carmel.pm
@@ -32,8 +32,8 @@ Carmel - CPAN Artifact Repository Manager
   # update all the modules in the snapshot
   carmel update
 
-  # Manually pull a module to build artifacts
-  carmel inject DBI@1.633 Plack@1.0000
+  # pin modules tp specific versions
+  carmel pin DBI@1.633 Plack@1.0000
 
   # Runs your perl script with modules from artifacts
   carmel exec perl ...

--- a/script/carmel
+++ b/script/carmel
@@ -36,8 +36,8 @@ carmel - CPAN Artifact Repository Manager
   # update all the modules in the snapshot
   carmel update
 
-  # Manually pull a module to build artifacts
-  carmel inject DBI@1.633 Plack@1.0000
+  # pin modules to specific versions
+  carmel pin DBI@1.633 Plack@1.0000
 
   # Runs your perl script with modules from artifacts
   carmel exec perl ...

--- a/xt/cli/pin.t
+++ b/xt/cli/pin.t
@@ -1,0 +1,26 @@
+use strict;
+use Test::More;
+use lib ".";
+use xt::CLI;
+
+subtest 'carmel pin' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'Class::Tiny';
+EOF
+
+    $app->run("install");
+
+    like( $app->snapshot->find("Class::Tiny")->name, qr/Class-Tiny-/ );
+    unlike( $app->snapshot->find("Class::Tiny")->name, qr/Class-Tiny-1\.003/ );
+
+    $app->run("pin", 'Class::Tiny@1.003');
+
+    $app->run("list");
+    like $app->stdout, qr/Class::Tiny \(1\.003\)/, "Use the version specified via pin";
+
+    like( $app->snapshot->find("Class::Tiny")->name, qr/Class-Tiny-1\.003/ );
+};
+
+done_testing;


### PR DESCRIPTION
Imagine you have cpanfile:

```
requires 'JSON', '4';
```

and the snapshot has the version 4.00.

You can update to the latest version available from CPAN with `carmel update JSON`. Let's say you don't want the version on CPAN today, and want to pin to a specific version. You can update cpanfile:

```
requires 'JSON', '== 4.04';
```

This works fine, but then you need to unpin every time you update to newer versions.

The new `carmel pin` command allows you to keep the version specification in `cpanfile` (so that future run of `carmel update` will update to the latest), while pinning to the specified version, rather than whatever is the latest on CPAN when you run it.

`carmel pin JSON@4.04` is essentially the same as:

- manually update `cpanfile` to have `requires 'JSON', '== 4.04';`
- run `carmel install` to pin the JSON version
- revert `cpanfile` to `requires 'JSON', '4';`
