### PR TITLE
Fix #38 when searching for artifacts, consider the root requirements

### DIFF
--- a/xt/cli/pin.t
+++ b/xt/cli/pin.t
@@ -23,4 +23,24 @@ EOF
     like( $app->snapshot->find("Class::Tiny")->name, qr/Class-Tiny-1\.003/ );
 };
 
+subtest 'bug #38' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'URI';
+requires 'URI::Escape';
+EOF
+
+    $app->run("install");
+    $app->run("pin", 'URI@5.09');
+
+    my @dists = grep { $_->name =~ /^URI-\d/ } $app->snapshot->distributions;
+    is @dists, 1, "should have 1 URI dist to cover both";
+
+    $app->run("install");
+
+    @dists = grep { $_->name =~ /^URI-\d/ } $app->snapshot->distributions;
+    is @dists, 1, "should have 1 URI dist after running install again";
+};
+
 done_testing;


### PR DESCRIPTION
Also remove the strict option to make it always strict, since I can't find cases where this condition is triggered.