### PR TITLE
use https mirror by default

### DIFF
--- a/lib/Carmel/Builder.pm
+++ b/lib/Carmel/Builder.pm
@@ -36,7 +36,6 @@ sub install {
         unshift @cmd,
           "--mirror-index", $path,
           "--cascade-search",
-          "--mirror", "http://cpan.metacpan.org";
     }
 
     local $ENV{PERL_CPANM_HOME} = $self->tempdir;
@@ -57,7 +56,7 @@ sub install {
     my $cli = Menlo::CLI::Compat->new;
     $cli->parse_options(
         ($Carmel::DEBUG ? () : "--quiet"),
-        ($mirror ? ("-M", $mirror) : ()),
+        ($mirror ? ("-M", $mirror) : ("--mirror", "https://cpan.metacpan.org/")),
         "--notest",
         "--save-dists", $self->repository_base->child('cache'),
         "-L", $lib,

--- a/xt/cli/update.t
+++ b/xt/cli/update.t
@@ -7,7 +7,7 @@ subtest 'carmel update with mirrors' => sub {
     my $app = cli();
 
     $app->write_cpanfile(<<EOF);
-mirror 'http://cpan.metacpan.org';
+mirror 'https://cpan.metacpan.org';
 requires 'Class::Tiny';
 EOF
 


### PR DESCRIPTION
Menlo uses plain text http mirror by default.

Carmel users can override this by using `mirror` in `cpanfile`, but this PR defaults to use the HTTPS mirror on MetaCPAN. I tested it on a stock perl with just Carmel installed, and Menlo (HTTP::Tinyish) worked just fine, using the wget backend.