### PR TITLE
Lazy load artifacts. prefer JSON backend for CPAN::Meta

### DIFF
--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -226,8 +226,7 @@ sub install {
     )->resolve;
 
     # $root_reqs has been mutated at this point. Reload requirements
-    printf "---> Complete! %d cpanfile dependencies. %d modules installed.\n" .
-      "---> Use `carmel show [module]` to see where a module is installed.\n",
+    printf "---> Complete! %d cpanfile dependencies. %d modules installed.\n",
       scalar(grep { $_ ne 'perl' } $self->requirements->required_modules), scalar(@artifacts);
 
     return @artifacts;

--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -17,6 +17,10 @@ use Path::Tiny ();
 use Pod::Usage ();
 use Try::Tiny;
 
+# prefer Parse::CPAN::Meta in XS, PP order with JSON.pm
+$ENV{PERL_JSON_BACKEND} = 1
+  unless defined $ENV{PERL_JSON_BACKEND};
+
 use Class::Tiny {
     verbose => sub { 0 },
     perl_arch => sub { "$Config{version}-$Config{archname}" },

--- a/lib/Carmel/Resolver.pm
+++ b/lib/Carmel/Resolver.pm
@@ -27,7 +27,7 @@ sub resolve_recurse {
         my $artifact;
         my $dist;
         if ($dist = $self->find_in_snapshot($module)) {
-            $artifact = $self->repo->find_match($module, sub { $_[0]->distname eq $dist->name });
+            $artifact = $self->repo->find_match($module, sub { $_[0]->distname eq $dist->name }, $dist->name);
         } elsif ($self->is_core($module, $want_version)) {
             next;
         } else {


### PR DESCRIPTION
- Lazy load all artifacts from `~/.carmel/builds` until an artifact for dist specified in snapshot is not found. This can shed about 80ms with 2K artifacts in the repository.
- Prefer JSON.pm backend (for XS, PP) in Parse::CPAN::Meta when loading `MYMETA.json`  for each artifact. This speeds up loading artifacts and saving snapshot.
