### PR TITLE
Handle core module versions in snapshot

### DIFF
--- a/lib/Carmel/Repository.pm
+++ b/lib/Carmel/Repository.pm
@@ -68,15 +68,19 @@ sub find_all {
     $self->_find($package, $want_version, 1);
 }
 
-sub find_match {
-    my($self, $package, $cb, $distname) = @_;
+sub find_dist {
+    my($self, $package, $distname) = @_;
 
-    if ($distname) {
-        my $dir = $self->path->child($distname);
-        if ($dir->exists) {
-            return Carmel::Artifact->new($dir);
-        }
+    my $dir = $self->path->child($distname);
+    if ($dir->exists) {
+        return Carmel::Artifact->new($dir);
     }
+
+    return $self->find_match($package, sub { $_[0]->distname eq $distname });
+}
+
+sub find_match {
+    my($self, $package, $cb) = @_;
 
     for my $artifact ($self->list($package)) {
         return $artifact if $cb->($artifact);

--- a/lib/Carmel/Resolver.pm
+++ b/lib/Carmel/Resolver.pm
@@ -34,10 +34,6 @@ sub resolve_recurse {
             $artifact = $self->repo->find_match($module, sub { $self->accepts_all($self->root, $_[0]) });
         }
 
-        if (!$artifact && $self->is_core($module, $want_version)) {
-            next;
-        }
-
         # FIXME there's a chance different version of the same module can be loaded here
         if ($artifact) {
             warn sprintf "   %s (%s) in %s\n", $module, $artifact->version_for($module), $artifact->path if $Carmel::DEBUG;
@@ -49,6 +45,10 @@ sub resolve_recurse {
 
             $self->resolve_recurse($reqs, $seen, $depth + 1);
         } else {
+            if ($dist) {
+                # TODO pass $dist->distfile to cpanfile
+                $want_version = $dist->version_for($module);
+            }
             $self->missing->($module, $want_version, $depth);
         }
     }

--- a/lib/Carmel/Resolver.pm
+++ b/lib/Carmel/Resolver.pm
@@ -27,7 +27,7 @@ sub resolve_recurse {
         my $artifact;
         my $dist = $self->find_in_snapshot($module);
         if ($dist) {
-            $artifact = $self->repo->find_match($module, sub { $_[0]->distname eq $dist->name }, $dist->name);
+            $artifact = $self->repo->find_dist($module, $dist->name);
         } elsif ($self->is_core($module, $want_version)) {
             next;
         } else {

--- a/lib/Carmel/Resolver.pm
+++ b/lib/Carmel/Resolver.pm
@@ -16,11 +16,6 @@ sub resolve {
     $self->resolve_recurse($clone, $seen, $depth);
 }
 
-sub find_artifact {
-    my($self, $module, $version) = @_;
-
-}
-
 sub resolve_recurse {
     my($self, $requirements, $seen, $depth) = @_;
 

--- a/xt/CLI.pm
+++ b/xt/CLI.pm
@@ -91,7 +91,7 @@ sub run_ok {
     $self->run(@args);
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    is $self->exit_code, 0
+    is $self->exit_code, 0, "carmel @args succeeded"
       or diag $self->stderr;
 }
 
@@ -101,7 +101,7 @@ sub run_fails {
     $self->run(@args);
 
     local $Test::Builder::Level = $Test::Builder::Level + 1;
-    is $self->exit_code, 1
+    is $self->exit_code, 1, "carmel @args failed"
       or diag $self->stderr;
 }
 

--- a/xt/cli/core.t
+++ b/xt/cli/core.t
@@ -5,19 +5,27 @@ use xt::CLI;
 
 use Module::CoreList;
 
-plan skip_all => "perl $] has HTTP::Tiny 0.056"
+plan skip_all => "perl $] has HTTP::Tiny eq 0.056"
   if $Module::CoreList::version{$]}{"HTTP::Tiny"} eq "0.056";
 
-subtest 'core modules in snapshots' => sub {
+for my $version (qw( 0.056 0.078 )) {
+    for my $clean (0, 1) {
+        subtest "core modules in snapshots (HTTP::Tiny $version) clean=$clean" => sub { test_it($version, $clean) };
+    }
+}
+
+sub test_it {
+    my($version, $clean) = @_;
+
     my $app = cli();
 
     $app->write_file('cpanfile.snapshot', <<EOF);
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
-  HTTP-Tiny-0.056
-    pathname: D/DA/DAGOLDEN/HTTP-Tiny-0.056.tar.gz
+  HTTP-Tiny-$version
+    pathname: D/DA/DAGOLDEN/HTTP-Tiny-$version.tar.gz
     provides:
-      HTTP::Tiny 0.056
+      HTTP::Tiny $version
     requirements:
       Carp 0
       Fcntl 0
@@ -35,31 +43,21 @@ EOF
 requires 'HTTP::Tinyish';
 EOF
 
-    # pull the artifact
-    $app->run_ok('inject', 'HTTP::Tiny@0.056');
+    my $is_new = $version > $Module::CoreList::version{$]}{"HTTP::Tiny"};
+
+    unless ($clean) {
+        # pull the artifact
+        $app->run_ok('inject', "HTTP::Tiny\@$version");
+    }
 
     $app->run_ok("install");
     unlike $app->stderr, qr/Can't find an artifact for HTTP::Tiny/;
 
     $app->run_ok("list");
-    like $app->stdout, qr/HTTP::Tiny \(0\.056\)/;
-
- SKIP: {
-        skip "HTTP::Tiny core verison < 0.056", 4
-          if $Module::CoreList::version{$]}{"HTTP::Tiny"} < 0.056;
-        skip "only runs under TEST_CLEAN", 4
-          unless $ENV{TEST_CLEAN};
-
-        # remove the build artifact
-        $app->dir->child('.carmel/builds/HTTP-Tiny-0.056')->remove_tree({ safe => 0 });
-
-        # #47 now, 0.056 artifact is removed, but is pinned in the snapshot
-        # Carmel should now upgrade it to the core version and remove it from the snapshot
-        $app->run_ok("install");
-        unlike $app->stderr, qr/Can't find an artifact for HTTP::Tiny/;
-
-        $app->run_ok("list");
-        unlike $app->stdout, qr/HTTP::Tiny \(0\.056/;
+    if ($is_new) {
+        like $app->stdout, qr/HTTP::Tiny \(\Q$version\E\)/;
+    } else {
+        unlike $app->stdout, qr/HTTP::Tiny /;
     }
 };
 

--- a/xt/cli/core.t
+++ b/xt/cli/core.t
@@ -14,6 +14,16 @@ for my $version (qw( 0.056 0.078 )) {
     }
 }
 
+subtest "core modules can still be pinned" => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'HTTP::Tiny', '== 0.056';
+EOF
+    $app->run_ok("install");
+    like $app->stdout, qr/HTTP::Tiny \(0\.056\)/;
+};
+
 sub test_it {
     my($version, $clean) = @_;
 


### PR DESCRIPTION
This is a major change in how core modules pinned in the snapshot works.

## Context

34b368726caa7a7d23e1f9b7389af4149d0c0a4f combined with 8ea6b68b6ba0fa10806467832f85fd9bedb0be55 introduced a bug where a core module pinned in the snapshot has always been ignored in the first carmel run (i.e. when the pinned version doesn't exist in the artifact repository).

If a version is pinned in the snapshot and has a higher version than the version shipped with perl, it's clear that Carmel should install that version. This is now fixed in this PR.

## Core Module in the Snapshot

If a version is pinned in the snapshot and has a lower version than core. It gets a little messy. Technically you could do this, but is difficult to implement with Menlo, because Menlo automatically skips this dependency, unless you pin to the exact version with what's in the snapshot, which caused some issues like #33 (removed the `== $ver` in 8ea6b68b6ba0fa10806467832f85fd9bedb0be55)

In this PR, I added a workaround and a behavior change as a result, so that if: 

- a version is pinned in the snapshot
- the version is not found in the artifact repository
- the version is lower than core version of the module

Carmel will ignore it and remove it from the snapshot, meaning that it would upgrade to the core version of the module. I think this is a safe behavior for core modules.

### Example

```
# cpanfile
requires 'HTTP::Tiny';
# cpanfile.snapshot
  HTTP-Tiny-0.056
    pathname: D/DA/DAGOLDEN/HTTP-Tiny-0.056.tar.gz
```

Because perl has a higher version of HTTP::Tiny than what's in the snapshot, and your cpanfile doesn't specify any version, the version pinning will be removed from the snapshot, on the first run of `carmel install`.

If you _really_ want to pin to the version that's older than core, you can still do this with:

```
# cpanfile
requires 'HTTP::Tiny', '== 0.056';
```

## First Installation

Related to this bug fix above, there's still a chance where you encounter `Can't find artifact for Module => version` in the first carmel run. Here's how this happens:

- carmel resolves the dependencies specified in `cpanfile` and uses the snapshot to install all of them
- Some transient dependencies that are core, and pinned in the snapshot, could be missed during the first run due to how the resolver works.

Usually this can be fixed by running `carmel install` again. This PR updates the install code so that the retry is unnecessary - it will automatically retry until there's no new missing modules from the installation.