### PR TITLE
unify pin and update command. Deprecate carmel pin

### DIFF
--- a/lib/Carmel.pm
+++ b/lib/Carmel.pm
@@ -33,7 +33,7 @@ Carmel - CPAN Artifact Repository Manager
   carmel update
 
   # pin modules tp specific versions
-  carmel pin DBI@1.633 Plack@1.0000
+  carmel update DBI@1.633 Plack@1.0000
 
   # Runs your perl script with modules from artifacts
   carmel exec perl ...

--- a/lib/Carmel/Builder.pm
+++ b/lib/Carmel/Builder.pm
@@ -76,7 +76,7 @@ sub install {
 }
 
 sub search_module {
-    my($self, $module) = @_;
+    my($self, $module, $version) = @_;
 
     local $ENV{PERL_CPANM_HOME} = $self->tempdir;
     local $ENV{PERL_CPANM_OPT};
@@ -88,6 +88,7 @@ sub search_module {
     my $mirror = Module::CPANfile->load($cpanfile)->mirrors->[0];
 
     require Menlo::CLI::Compat;
+    require Carton::Dist;
 
     my $cli = Menlo::CLI::Compat->new;
     $cli->parse_options(
@@ -98,8 +99,19 @@ sub search_module {
         ".",
     );
 
-    my $dist = $cli->search_module($module);
-    return $dist->{pathname} if $dist;
+    my $dist = $cli->search_module($module, $version);
+    if ($dist) {
+        return Carton::Dist->new(
+            name => $dist->{distvname},
+            pathname => $dist->{pathname},
+            provides => {
+                $dist->{module} => {
+                    version => $dist->{module_version},
+                },
+            },
+            version => $dist->{version},
+        );
+    }
 
     return;
 }

--- a/script/carmel
+++ b/script/carmel
@@ -37,7 +37,7 @@ carmel - CPAN Artifact Repository Manager
   carmel update
 
   # pin modules to specific versions
-  carmel pin DBI@1.633 Plack@1.0000
+  carmel update DBI@1.633 Plack@1.0000
 
   # Runs your perl script with modules from artifacts
   carmel exec perl ...

--- a/xt/cli/pin.t
+++ b/xt/cli/pin.t
@@ -3,7 +3,7 @@ use Test::More;
 use lib ".";
 use xt::CLI;
 
-subtest 'carmel pin' => sub {
+subtest 'carmel update with pinning' => sub {
     my $app = cli();
 
     $app->write_cpanfile(<<EOF);
@@ -15,7 +15,7 @@ EOF
     like( $app->snapshot->find("Class::Tiny")->name, qr/Class-Tiny-/ );
     unlike( $app->snapshot->find("Class::Tiny")->name, qr/Class-Tiny-1\.003/ );
 
-    $app->run_ok("pin", 'Class::Tiny@1.003');
+    $app->run_ok("update", 'Class::Tiny@1.003');
 
     $app->run_ok("list");
     like $app->stdout, qr/Class::Tiny \(1\.003\)/, "Use the version specified via pin";
@@ -32,7 +32,7 @@ requires 'URI::Escape';
 EOF
 
     $app->run_ok("install");
-    $app->run_ok("pin", 'URI@5.09');
+    $app->run_ok("update", 'URI@5.09');
 
     my @dists = grep { $_->name =~ /^URI-\d/ } $app->snapshot->distributions;
     is @dists, 1, "should have 1 URI dist to cover both";


### PR DESCRIPTION
I realized `carmel pin` is a misnomer and gives a false impression that it creates a pin in cpanfile. That's not the case, and `carmel pin` works pretty similar to how `carmel update` works, except that it can pin the version.

This PR unifies the `carmel update` and `carmel pin` so that `carmel update Plack@1.0` would update the module to the specified version.  You can mix and match multiple modules as well.

```
# update everything to the latest
carmel update

# update Plack to 1.000
carmel update Plack@1.000

# update Try::Tiny to the latest on CPAN
carmel update Try::Tiny

# do both in one command
carmel update Plack@1.000 Try::Tiny
```

`carmel pin` is now deprecated.