### PR TITLE
implement carmel diff

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -35,4 +35,4 @@ jobs:
           cpanm -nq --dev Menlo Carton && \
           cpanm -nq --with-develop --installdeps .
       - name: Run Tests
-        run: prove -lr xt
+        run: prove -j10 -lr xt

--- a/cpanfile
+++ b/cpanfile
@@ -11,6 +11,7 @@ requires 'Module::Metadata', '1.000003';
 requires 'Path::Tiny', '0.068';
 requires 'Try::Tiny', '0.20';
 requires 'File::Copy::Recursive';
+requires 'CPAN::DistnameInfo';
 
 requires 'File::pushd', '1.009';
 requires 'ExtUtils::Install', '1.47';

--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -422,11 +422,11 @@ sub cmd_list {
 sub cmd_diff {
     my $self = shift;
 
-    unless (-e '.git') {
-        die "carmel diff only supports Git for now\n";
-    }
+    my $snapshot_path = $self->cpanfile->snapshot_path->relative;
 
-    my $snapshot_path = $self->locate_cpanfile->relative . '.snapshot';
+    unless ($snapshot_path->parent->child('.git')->exists) {
+        die "not a git repository: Can't locate .git directory\n";
+    }
 
     if ($ENV{CARMEL_USE_DIFFTOOL}) {
         my $cmd = 'carmel difftool';
@@ -438,7 +438,7 @@ sub cmd_diff {
         require Carmel::Difftool;
 
         my $content = `git show HEAD:$snapshot_path`
-          or die "carmel diff: Can't retrieve snapshot content\n";
+          or die "Can't retrieve snapshot content for $snapshot_path\n";
         my $path = Path::Tiny->tempfile;
         $path->spew($content);
 

--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -424,9 +424,7 @@ sub cmd_diff {
 
     my $snapshot_path = $self->cpanfile->snapshot_path->relative;
 
-    unless ($snapshot_path->parent->child('.git')->exists) {
-        die "not a git repository: Can't locate .git directory\n";
-    }
+    # Don't check if .git exists, and let git(2) handle the error
 
     if ($ENV{CARMEL_USE_DIFFTOOL}) {
         my $cmd = 'carmel difftool';

--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -419,6 +419,43 @@ sub cmd_list {
     }
 }
 
+sub cmd_diff {
+    my $self = shift;
+
+    unless (-e '.git') {
+        die "carmel diff only supports Git for now\n";
+    }
+
+    my $snapshot_path = $self->locate_cpanfile->relative . '.snapshot';
+
+    if ($ENV{CARMEL_USE_DIFFTOOL}) {
+        my $cmd = 'carmel difftool';
+        $cmd .= ' -v' if $self->verbose;
+
+        system 'git', 'difftool', '--no-prompt',
+          '--extcmd', $cmd, $snapshot_path;
+    } else {
+        require Carmel::Difftool;
+
+        my $content = `git show HEAD:$snapshot_path`
+          or die "carmel diff: Can't retrieve snapshot content\n";
+        my $path = Path::Tiny->tempfile;
+        $path->spew($content);
+
+        my $diff = Carmel::Difftool->new;
+        $diff->diff($path, $snapshot_path);
+    }
+}
+
+sub cmd_difftool {
+    my($self, @args) = @_;
+
+    require Carmel::Difftool;
+
+    my $diff = Carmel::Difftool->new;
+    $diff->diff(@args);
+}
+
 sub resolve {
     my($self, $cb) = @_;
     $self->resolver(found => $cb)->resolve;

--- a/lib/Carmel/Difftool.pm
+++ b/lib/Carmel/Difftool.pm
@@ -1,0 +1,86 @@
+package Carmel::Difftool;
+use strict;
+use warnings;
+
+use Carton::Snapshot;
+use CPAN::DistnameInfo;
+use Class::Tiny;
+use version;
+
+use constant RED => 31;
+use constant GREEN => 32;
+use constant PURPLE => 35;
+
+sub color {
+    my($code, $text) = @_;
+    return $text unless -t STDOUT && !$ENV{NO_COLOR};
+    return "\e[${code}m${text}\e[0m";
+}
+
+sub load_snapshot {
+    my($self, $file, $dists, $index) = @_;
+
+    my $snapshot = Carton::Snapshot->new(path => $file);
+    $snapshot->load;
+
+    for my $dist ($snapshot->distributions) {
+        (my $path = $dist->pathname) =~ s!^[A-Z]/[A-Z]{2}/!!;
+        my $info = CPAN::DistnameInfo->new($path);
+        $dists->{$info->dist}[$index] = $info;
+    }
+}
+
+sub diff {
+    my($self, @args) = @_;
+
+    my %dists;
+    $self->load_snapshot($args[0], \%dists, 0);
+    $self->load_snapshot($args[1], \%dists, 1);
+
+    for my $dist (sort keys %dists) {
+        $self->print_diff($dist, @{$dists{$dist}});
+    }
+}
+
+sub print_diff {
+    my($self, $dist, $old, $new) = @_;
+
+    # unchanged
+    return if $old && $new && $old->distvname eq $new->distvname;
+
+    # added
+    if (!$old && $new) {
+        if ($Carmel::DEBUG) {
+            printf "%s (%s)\n%s\n", $dist,
+              color(GREEN, $new->version),
+              color(GREEN, "+ " . $new->pathname);
+        } else {
+            printf "+ %s (%s)\n", $dist, color(GREEN, $new->version);
+        }
+        return;
+    }
+
+    # removed
+    if ($old && !$new) {
+        if ($Carmel::DEBUG) {
+            printf "%s (%s)\n%s\n", $dist,
+              color(RED, $old->version),
+              color(RED, "- " . $old->pathname);
+        } else {
+            printf "- %s (%s)\n", $dist, color(RED, $old->version);
+        }
+        return;
+    }
+
+    if ($Carmel::DEBUG) {
+        printf "%s (%s -> %s)\n%s\n%s\n", $dist,
+          color(RED, $old->version), color(GREEN, $new->version),
+          color(RED, "- " . $old->pathname), color(GREEN, "+ " . $new->pathname);
+    } else {
+        printf "  %s (%s -> %s)\n", $dist, color(RED, $old->version), color(GREEN, $new->version);
+    }
+}
+
+1;
+
+

--- a/lib/Carmel/Difftool.pm
+++ b/lib/Carmel/Difftool.pm
@@ -4,12 +4,11 @@ use warnings;
 
 use Carton::Snapshot;
 use CPAN::DistnameInfo;
-use Class::Tiny;
 use version;
+use Class::Tiny;
 
 use constant RED => 31;
 use constant GREEN => 32;
-use constant PURPLE => 35;
 
 sub color {
     my($code, $text) = @_;
@@ -82,5 +81,3 @@ sub print_diff {
 }
 
 1;
-
-

--- a/xt/CLI.pm
+++ b/xt/CLI.pm
@@ -82,6 +82,16 @@ sub cmd {
     $self->stderr($capture[1]);
 }
 
+sub cmd_ok {
+    my($self, @args) = @_;
+
+    $self->cmd(@args);
+
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+    is $self->exit_code, 0, "carmel @args succeeded"
+      or diag $self->stderr;
+}
+
 sub run_in_dir {
     my($self, $dir, @args) = @_;
     local $self->{dir} = $self->dir->child($dir);

--- a/xt/CLI.pm
+++ b/xt/CLI.pm
@@ -63,6 +63,25 @@ sub repo {
     Carmel::App->new->build_repo;
 }
 
+sub cmd_in_dir {
+    my($self, $dir, @args) = @_;
+    local $self->{dir} = $self->dir->child($dir);
+    $self->run(@args);
+}
+
+sub cmd {
+    my($self, @args) = @_;
+
+    my $pushd = File::pushd::pushd $self->dir;
+    my @capture = capture {
+        my $code = system @args;
+        $self->exit_code($code);
+    };
+
+    $self->stdout($capture[0]);
+    $self->stderr($capture[1]);
+}
+
 sub run_in_dir {
     my($self, $dir, @args) = @_;
     local $self->{dir} = $self->dir->child($dir);

--- a/xt/cli/diff.t
+++ b/xt/cli/diff.t
@@ -14,9 +14,9 @@ EOF
     $app->run_fails("diff");
     like $app->stderr, qr/Can't retrieve snapshot content/;
 
-    $app->cmd("git", "init");
-    $app->cmd("git", "add", ".");
-    $app->cmd("git", "commit", "-m", "initial");
+    $app->cmd_ok("git", "init");
+    $app->cmd_ok("git", "add", ".");
+    $app->cmd_ok("git", "commit", "-m", "initial");
 
     $app->write_cpanfile(<<EOF);
 requires 'Class::Tiny';

--- a/xt/cli/diff.t
+++ b/xt/cli/diff.t
@@ -1,0 +1,35 @@
+use strict;
+use Test::More;
+use lib ".";
+use xt::CLI;
+
+subtest 'carmel diff' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<EOF);
+requires 'Class::Tiny', '== 1.006';
+EOF
+
+    $app->run_ok("install");
+    $app->run_fails("diff");
+    like $app->stderr, qr/Can't retrieve snapshot content/;
+
+    $app->cmd("git", "init");
+    $app->cmd("git", "add", ".");
+    $app->cmd("git", "commit", "-m", "initial");
+
+    $app->write_cpanfile(<<EOF);
+requires 'Class::Tiny';
+EOF
+
+    $app->run_ok("update");
+    $app->run_ok("diff");
+    like $app->stdout, qr/Class-Tiny \(1\.006 -> /;
+
+    $app->dir->child('t')->mkpath;
+    $app->run_in_dir('t', "diff");
+    like $app->stdout, qr/Class-Tiny \(1\.006 -> /;
+      
+};
+
+done_testing;

--- a/xt/cli/diff.t
+++ b/xt/cli/diff.t
@@ -6,6 +6,11 @@ use xt::CLI;
 subtest 'carmel diff' => sub {
     my $app = cli();
 
+    if ($ENV{CI}) {
+        $app->cmd_ok("git", "config", "--global", "user.email", 'test@example.com');
+        $app->cmd_ok("git", "config", "--global", "user.name", "Test");
+    }
+
     $app->write_cpanfile(<<EOF);
 requires 'Class::Tiny', '== 1.006';
 EOF


### PR DESCRIPTION
Doesn't this look nice? 😍 

<img width="409" alt="image" src="https://user-images.githubusercontent.com/3499/167529603-06ea0615-a33d-4b8c-bce8-d9c92eec4402.png">

`carmel difftool` runs as a difftool for `cpanfile.snapshot` files, so users of Carton (or otherwise manually generating the snapshot files) can also use it without using Carmel.

Running `carmel diff` basically does the same without going the hoops of using the `git difftool`, though I made it to also work as a difftool wrapper as well.