### PR TITLE
The first carmel install (without snapshot) should install the latest. Fix #53

### DIFF
--- a/xt/cli/update_core.t
+++ b/xt/cli/update_core.t
@@ -8,7 +8,7 @@ use Module::CoreList;
 plan skip_all => "HTTP::Tiny is not in core or is possibly the latest"
   if ($Module::CoreList::version{$]}{"HTTP::Tiny"} || 999) > 0.080;
 
-subtest 'carmel update core-module with empty cpanfile' => sub {
+subtest 'carmel install now installs core module if there is a new version' => sub {
     my $app = cli();
 
     $app->write_cpanfile(<<EOF);
@@ -17,27 +17,30 @@ EOF
 
     $app->run_ok("install");
     $app->run_ok("list");
-    is $app->stdout, '';
-
-    $app->run_ok("update", "HTTP::Tiny");
-    $app->run_ok("list", "HTTP::Tiny");
     like $app->stdout, qr/HTTP::Tiny \(/;
 };
 
-subtest 'carmel update with empty cpanfile' => sub {
+subtest 'carmel update updates core modules' => sub {
     my $app = cli();
 
+    # this creates an empty snapshot
+    $app->write_cpanfile('');
+    $app->run_ok("install");
+
+    # now add HTTP::Tiny, it will use the core version
+    # BUG: this is actually an inconsistent behavior from first-run
     $app->write_cpanfile(<<EOF);
 requires 'HTTP::Tiny';
 EOF
 
     $app->run_ok("install");
     $app->run_ok("list");
+    unlike $app->stdout, qr/HTTP::Tiny \(/;
 
+    # now, carmel update will update it because it's in cpanfile
     $app->run_ok("update");
     $app->run_ok("list", "HTTP::Tiny");
     like $app->stdout, qr/HTTP::Tiny \(/;
 };
-
 
 done_testing;


### PR DESCRIPTION
When you run `carmel install` for the first time in your project, it scans your artifact repository for versions satisfying the requirements. This makes the initial install fast, but has a potential risk where it could pull a very old version of the module if it happens to be the only version available in the repository.

This means, with the same `cpanfile`, without `cpanfile.snapshot`, could yield different snapshot based on user's environments, depending on what build cache they have, even when they run exactly at the same time. This is not a great user experience.

This PR changes it so that it will install the latest version available on CPAN and that makes it more consistent, while still giving the benefit of being able to pin the version if they want to, explicitly with `carmel update Module@version`. This basically gives the same results if you run `cpanm -L ./local --installdeps .` initially, or run `carton install` without the snapshot.

In other words, the first `carmel install` run when `cpanfile.snapshot` doesn't exist, works like you do `carmel install && carmel update`.

One remaining issue, if you do:

1. Create `cpanfile`, run `carmel install`
2. Add a new dependency, run `carmel install`

Then for the new dependency, it can still pull a (potentially old) version from the artifact repository, which sounds inconsistent. That behavior is not resolved in this PR yet.
