### PR TITLE
in update, no need to remove it from the snapshot

### DIFF
--- a/lib/Carmel/App.pm
+++ b/lib/Carmel/App.pm
@@ -138,13 +138,6 @@ sub update_or_install {
             }
         }
 
-        if ($dist->pathname ne $pathname && $snapshot) {
-            $snapshot->remove_distributions(sub {
-                my $dist = shift;
-                $dist->provides_module($module);
-            });
-        }
-
         if (defined $version) {
             try {
                 $requirements->add_string_requirement($module, $version);


### PR DESCRIPTION
When `carmel update` runs, the code searches on CPAN for a new version, and when it is found, the module is removed from the snapshot. So that later search won't find the version that's pinned. 

This seems unnecessary, since we update `$requirements` to point to the new version, whether it's pinned or not, and that will be passed to Menlo and it will do the right thing.

The only situation it could behave differently is that if the snapshot has a higher version than what is currently up on CPAN. The current code (removing it from snapshot) will downgrade to the CPAN version. By keeping the snapshot, the new behavior is to prefer the snapshot.

I think the new behavior is fine, and you can always downgrade with `carmel update Module@version`.