### PR TITLE
EXPERIMENTAL: Fix invalid metadata for CPAN modules

### DIFF
--- a/lib/Carmel/Artifact.pm
+++ b/lib/Carmel/Artifact.pm
@@ -1,13 +1,22 @@
 package Carmel::Artifact;
 use strict;
+use Carmel::Patch;
 use CPAN::Meta;
 use JSON ();
 use Path::Tiny ();
 
-sub new {
-    my($class, $path) = @_;
-    bless { path => Path::Tiny->new($path) }, $class;
+sub load {
+    my($class, $dir) = @_;
+
+    my $path = Path::Tiny->new($dir);
+    my $patch = Carmel::Patch->lookup($path->basename);
+
+    my $self = bless { path => $path }, $patch || $class;
+    $self->init();
+    $self;
 }
+
+sub init {}
 
 sub path { $_[0]->{path} }
 
@@ -118,7 +127,7 @@ sub sharedir_libs {
 
 sub meta {
     my $self = shift;
-    CPAN::Meta->load_file($self->path->child("MYMETA.json"));
+    $self->{meta} ||= CPAN::Meta->load_file($self->path->child("MYMETA.json"));
 }
 
 sub requirements {

--- a/lib/Carmel/DefaultPatches.pm
+++ b/lib/Carmel/DefaultPatches.pm
@@ -1,0 +1,20 @@
+package Carmel::DefaultPatches;
+use strict;
+use Carmel::Patch;
+
+Carmel::Patch->add(
+    'Time-Piece-MySQL-0.06' => {
+        init => sub {
+            my $self = shift;
+            delete $self->install->{provides}{"Time::Piece"};
+        },
+    },
+    'Proc-PID-File-Fcntl-1.01' => {
+        init => sub {
+            my $self = shift;
+            $self->install->{provides}{"Proc::PID::File::Fcntl"}{version} = "1.01";
+        },
+    },
+);
+
+1;

--- a/lib/Carmel/DefaultPatches.pm
+++ b/lib/Carmel/DefaultPatches.pm
@@ -1,20 +1,19 @@
 package Carmel::DefaultPatches;
 use strict;
-use Carmel::Patch;
+use Carmel::Patch qw(patch);
 
-Carmel::Patch->add(
-    'Time-Piece-MySQL-0.06' => {
-        init => sub {
-            my $self = shift;
-            delete $self->install->{provides}{"Time::Piece"};
-        },
+patch 'Time-Piece-MySQL-0.06' => {
+    init => sub {
+        my $self = shift;
+        delete $self->install->{provides}{"Time::Piece"};
     },
-    'Proc-PID-File-Fcntl-1.01' => {
-        init => sub {
-            my $self = shift;
-            $self->install->{provides}{"Proc::PID::File::Fcntl"}{version} = "1.01";
-        },
+};
+
+patch 'Proc-PID-File-Fcntl-1.01' => {
+    init => sub {
+        my $self = shift;
+        $self->install->{provides}{"Proc::PID::File::Fcntl"}{version} = "1.01";
     },
-);
+};
 
 1;

--- a/lib/Carmel/Patch.pm
+++ b/lib/Carmel/Patch.pm
@@ -5,8 +5,10 @@ use warnings;
 my %patches;
 
 sub add {
-    my($class, $name, $patch) = @_;
-    $patches{$name} = $class->new($name, $patch);
+    my($class, %args) = @_;
+    while (my($name, $patch) = each %args) {
+        $patches{$name} = $class->new($name, $patch);
+    }
 }
 
 sub new {
@@ -35,6 +37,12 @@ __PACKAGE__->add(
         init => sub {
             my $self = shift;
             delete $self->install->{provides}{"Time::Piece"};
+        },
+    },
+    'Proc-PID-File-Fcntl-1.01' => {
+        init => sub {
+            my $self = shift;
+            $self->install->{provides}{"Proc::PID::File::Fcntl"}{version} = "1.01";
         },
     },
 );

--- a/lib/Carmel/Patch.pm
+++ b/lib/Carmel/Patch.pm
@@ -32,19 +32,8 @@ sub lookup {
     $patches{$distname};
 }
 
-__PACKAGE__->add(
-    'Time-Piece-MySQL-0.06' => {
-        init => sub {
-            my $self = shift;
-            delete $self->install->{provides}{"Time::Piece"};
-        },
-    },
-    'Proc-PID-File-Fcntl-1.01' => {
-        init => sub {
-            my $self = shift;
-            $self->install->{provides}{"Proc::PID::File::Fcntl"}{version} = "1.01";
-        },
-    },
-);
+unless ($ENV{PERL_CARMEL_NO_DEFAULT_PATCHES}) {
+    require Carmel::DefaultPatches;
+}
 
 1;

--- a/lib/Carmel/Patch.pm
+++ b/lib/Carmel/Patch.pm
@@ -2,13 +2,14 @@ package Carmel::Patch;
 use strict;
 use warnings;
 
+use parent 'Exporter';
+our @EXPORT = qw(patch);
+
 my %patches;
 
-sub add {
-    my($class, %args) = @_;
-    while (my($name, $patch) = each %args) {
-        $patches{$name} = $class->new($name, $patch);
-    }
+sub patch {
+    my($name, $patch) = @_;
+    $patches{$name} = __PACKAGE__->new($name, $patch);
 }
 
 sub new {
@@ -18,7 +19,7 @@ sub new {
     $pkg = "Carmel::Artifact::$pkg";
 
     no strict 'refs';
-    @{"$pkg\::ISA"} = qw( Carmel::Artifact );
+    @{"$pkg\::ISA"} = ("Carmel::Artifact");
 
     for my $hook (keys %$hooks) {
         *{"$pkg\::$hook"} = $hooks->{$hook};

--- a/lib/Carmel/Patch.pm
+++ b/lib/Carmel/Patch.pm
@@ -1,0 +1,42 @@
+package Carmel::Patch;
+use strict;
+use warnings;
+
+my %patches;
+
+sub add {
+    my($class, $name, $patch) = @_;
+    $patches{$name} = $class->new($name, $patch);
+}
+
+sub new {
+    my($class, $name, $hooks) = @_;
+
+    (my $pkg = $name) =~ s/([^A-Za-z0-9_])/sprintf "_%x", ord($1)/eg;
+    $pkg = "Carmel::Artifact::$pkg";
+
+    no strict 'refs';
+    @{"$pkg\::ISA"} = qw( Carmel::Artifact );
+
+    for my $hook (keys %$hooks) {
+        *{"$pkg\::$hook"} = $hooks->{$hook};
+    }
+
+    return $pkg;
+}
+
+sub lookup {
+    my($class, $distname) = @_;
+    $patches{$distname};
+}
+
+__PACKAGE__->add(
+    'Time-Piece-MySQL-0.06' => {
+        init => sub {
+            my $self = shift;
+            delete $self->install->{provides}{"Time::Piece"};
+        },
+    },
+);
+
+1;

--- a/lib/Carmel/Repository.pm
+++ b/lib/Carmel/Repository.pm
@@ -50,7 +50,7 @@ sub load_artifacts {
 sub load {
     my($self, $dir) = @_;
 
-    my $artifact = Carmel::Artifact->new($dir);
+    my $artifact = Carmel::Artifact->load($dir);
     while (my($package, $data) = each %{ $artifact->provides }) {
         $self->add($package, $artifact);
     }
@@ -78,7 +78,7 @@ sub find_dist {
 
     my $dir = $self->path->child($distname);
     if ($dir->exists) {
-        return Carmel::Artifact->new($dir);
+        return Carmel::Artifact->load($dir);
     }
 
     return $self->find_match($package, sub { $_[0]->distname eq $distname });

--- a/xt/cli/bad_provides.t
+++ b/xt/cli/bad_provides.t
@@ -1,0 +1,19 @@
+# https://github.com/miyagawa/Carmel/issues/89
+use strict;
+use Test::More;
+use lib ".";
+use xt::CLI;
+
+subtest 'Time::Piece::MySQL' => sub {
+    my $app = cli();
+
+    $app->write_cpanfile(<<'EOF');
+requires 'Time::Piece::MySQL';
+requires 'Test::MockTime';
+EOF
+
+    $app->run_ok('install');
+};
+
+done_testing;
+

--- a/xt/cli/bad_provides.t
+++ b/xt/cli/bad_provides.t
@@ -1,9 +1,9 @@
-# https://github.com/miyagawa/Carmel/issues/89
 use strict;
 use Test::More;
 use lib ".";
 use xt::CLI;
 
+# https://github.com/miyagawa/Carmel/issues/89
 subtest 'Time::Piece::MySQL' => sub {
     my $app = cli();
 
@@ -15,5 +15,15 @@ EOF
     $app->run_ok('install');
 };
 
-done_testing;
+# https://github.com/miyagawa/Carmel/issues/71
+subtest 'Proc::PID::File::Fcntl' => sub {
+    my $app = cli();
 
+    $app->write_cpanfile(<<'EOF');
+requires 'Proc::PID::File::Fcntl';
+EOF
+
+    $app->run_ok('install');
+};
+
+done_testing;


### PR DESCRIPTION
This creates a framework to register patches to fix broken metadata in various CPAN modules.

Currently the API should be considered unstable and there's no way to call this automatically, but I can imagine this can be configured in `.carmel` to be automatically included whenever you run `carmel`.