### PR TITLE
Drop unused dependencies CPAN::Common::Index, CPAN::Meta::Prereqs

### DIFF
--- a/META.json
+++ b/META.json
@@ -39,9 +39,7 @@
       },
       "runtime" : {
          "requires" : {
-            "CPAN::Common::Index" : "0.006",
             "CPAN::DistnameInfo" : "0",
-            "CPAN::Meta::Prereqs" : "2.132830",
             "CPAN::Meta::Requirements" : "2.129",
             "Carton" : "v1.0.35",
             "Class::Tiny" : "1.001",

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -50,9 +50,7 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
-  "CPAN::Common::Index" => "0.006",
   "CPAN::DistnameInfo" => 0,
-  "CPAN::Meta::Prereqs" => "2.132830",
   "CPAN::Meta::Requirements" => "2.129",
   "Carton" => "1.0.35",
   "Class::Tiny" => "1.001",

--- a/cpanfile
+++ b/cpanfile
@@ -3,7 +3,6 @@ requires 'perl', '5.014000';
 requires 'JSON';
 requires 'Class::Tiny', '1.001';
 requires 'CPAN::Meta::Requirements', '2.129';
-requires 'CPAN::Meta::Prereqs', '2.132830';
 requires 'Module::CoreList';
 requires 'Module::CPANfile', '1.1000';
 requires 'Module::Runtime', '0.014';
@@ -21,7 +20,6 @@ requires 'Carton', 'v1.0.35';
 
 # vendor
 requires 'Menlo::CLI::Compat', '1.9018';
-requires 'CPAN::Common::Index', '0.006';
 
 on test => sub {
     requires 'Test::More', '0.96';


### PR DESCRIPTION
These modules don’t appear to be used anywhere in recent versions of the code.